### PR TITLE
Add server-backed session feed for kiosk

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,21 +66,9 @@
       <!-- Extension buttons inserted here -->
     </div>
 
-    <!-- Google Sign-In Button (hidden unless needed) -->
-    <button
-      id="authorize_button"
-      style="display:none;"
-      onclick="handleAuthClick()"
-    >
-      Sign in with Google
-    </button>
   </div>
 
   <!-- Load your custom logic first -->
   <script src="script.js"></script>
-
-  <!-- Load Google APIs (must come after script.js so gapiLoaded() is defined) -->
-  <script src="https://apis.google.com/js/api.js" onload="gapiLoaded()"></script>
-  <script src="https://accounts.google.com/gsi/client" async defer></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,140 +1,192 @@
-// ------------------- Configuration & OAuth -------------------
-const CLIENT_ID = "991293667384-b654jos0v2e8mbgqr8q50ck4hantv8tf.apps.googleusercontent.com";
-// combine Calendar + Sheets scopes (read/write Sheets)
-const SCOPES = [
-  "https://www.googleapis.com/auth/calendar",
-  "https://www.googleapis.com/auth/spreadsheets"
-].join(" ");
-
-let tokenClient;
-let gapiInited = false;
-
-// This function is called by <script onload="gapiLoaded()"> in index.html
-function gapiLoaded() {
-  gapi.load("client", initializeGapiClient);
-}
-
-async function initializeGapiClient() {
-  await gapi.client.init({
-    discoveryDocs: [
-      "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest",
-      "https://sheets.googleapis.com/$discovery/rest?version=v4"
-    ]
-  });
-  maybeAutoAuth();
-}
-
-function maybeAutoAuth() {
-  tokenClient.requestAccessToken({ prompt: "" });
-  setTimeout(() => {
-    if (!gapi.client.getToken()) {
-      document.getElementById("authorize_button").style.display = "inline-block";
-    }
-  }, 2000);
-}
-
-window.onload = () => {
-  tokenClient = google.accounts.oauth2.initTokenClient({
-    client_id: CLIENT_ID,
-    scope:     SCOPES,
-    prompt:    "",
-callback: (resp) => {
-  if (resp.access_token) {
-    gapi.client.setToken(resp);
-    document.getElementById("authorize_button").style.display = "none"; // ✅ hide the button
-    listEvents();
+function resolveApiBaseUrl() {
+  if (window.APP_API_BASE_URL) {
+    return window.APP_API_BASE_URL;
   }
-}
-  });
-};
 
-function handleAuthClick() {
-  tokenClient.requestAccessToken();
+  if (window.location.protocol === "file:") {
+    return "http://localhost:3001";
+  }
+
+  const hostname = window.location.hostname;
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return "http://localhost:3001";
+  }
+
+  return "";
 }
 
-// ------------------- UI Elements & Prices -------------------
-const extensionDiv    = document.getElementById("extension-options");
-const countdownAlert  = document.getElementById("countdown-alert");
-const countdownText   = document.getElementById("countdown");
+const API_BASE_URL = resolveApiBaseUrl().replace(/\/$/, "");
+
+const extensionDiv = document.getElementById("extension-options");
+const countdownAlert = document.getElementById("countdown-alert");
+const countdownText = document.getElementById("countdown");
 const sessionTimeText = document.getElementById("session-time");
+const timeRemainingEl = document.getElementById("time-remaining");
 
-// Extension pricing options
 const extensionOptions = [
   { minutes: 15, price: "$22" },
   { minutes: 30, price: "$43" },
-  { minutes: 60, price: "$84.96" }
+  { minutes: 60, price: "$84.96" },
 ];
 
-// Hide the countdown alert until needed
-countdownAlert.style.display = "none";
+const eventExtensionOptions = [
+  { minutes: 30, price: "$53.10" },
+  { minutes: 60, price: "$106.20" },
+];
 
-// ------------------- Fetch & Display Calendar Events -------------------
-function listEvents() {
-  const now      = new Date();
-  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+let countdownInterval = null;
 
-  gapi.client.calendar.events
-    .list({
-      calendarId:   "2l28nlc148jqqc7uk24u5jr9cs@group.calendar.google.com",
-      timeMin:      new Date(now.getTime() - 60 * 60 * 1000).toISOString(),
-      timeMax:      tomorrow.toISOString(),
-      showDeleted:  false,
-      singleEvents: true,
-      maxResults:   10,
-      orderBy:      "startTime"
-    })
-    .then(response => {
-      handleLiveEvents(response.result.items);
-    })
-    .catch(error => {
-      console.error("❌ Calendar error:", error);
-    });
+document.addEventListener("DOMContentLoaded", () => {
+  if (countdownAlert) {
+    countdownAlert.style.display = "none";
+  }
+  loadActiveSession();
+});
+
+async function loadActiveSession() {
+  clearCountdown();
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/active-session`);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    handleSessionData(data);
+  } catch (error) {
+    console.error("❌ Failed to fetch active session:", error);
+    sessionTimeText.textContent = "Unable to load session";
+    extensionDiv.innerHTML = "";
+  }
 }
 
-// ------------------- Main Logic: Identify & Display Current Session -------------------
-function handleLiveEvents(events) {
-  const now = new Date();
-
-  // Find the event where “now” is between its start and end
-  const current = events.find(evt => {
-    const start = new Date(evt.start.dateTime);
-    const end   = new Date(evt.end.dateTime);
-    return now >= start && now < end;
-  });
-
-  if (!current) {
+function handleSessionData({ currentSession, nextFreeBlock }) {
+  if (!currentSession || !currentSession.start || !currentSession.end) {
     sessionTimeText.textContent = "No active session";
-    console.log("ℹ️ No session currently running.");
+    displayClientName("");
+    extensionDiv.innerHTML = "";
     return;
   }
 
-  // Store for later extension logic
-  window.currentEventId          = current.id;
-  window.originalEventTitle      = current.summary || "Session";
-  window.sessionStartTime        = new Date(current.start.dateTime);
-  window.sessionEndTime          = new Date(current.end.dateTime);
-  window.currentEventDescription = current.description || "";
+  const start = new Date(currentSession.start);
+  const end = new Date(currentSession.end);
+  const isEvent = (currentSession.summary || "").toLowerCase().includes("event");
 
-  const isEvent = current.summary.toLowerCase().includes("event");
-  window.sessionClientName = extractClientName(current, isEvent);
+  window.currentEventId = currentSession.id;
+  window.originalEventTitle = currentSession.summary || "Session";
+  window.sessionStartTime = start;
+  window.sessionEndTime = end;
+  window.currentEventDescription = currentSession.description || "";
 
-  // Display client name & session time
-  displayClientName(window.sessionClientName);
-  const startTime = new Date(current.start.dateTime);
-  const endTime   = new Date(current.end.dateTime);
-  sessionTimeText.textContent = `${formatTime(startTime)} - ${formatTime(endTime)}`;
+  const clientName = extractClientName(currentSession.summary, isEvent);
+  window.sessionClientName = clientName;
 
-  // Begin the countdown
-  startCountdown(endTime, isEvent, events);
+  displayClientName(clientName);
+  sessionTimeText.textContent = `${formatTime(start)} - ${formatTime(end)}`;
+
+  const availableMinutes = Math.max(
+    0,
+    nextFreeBlock && typeof nextFreeBlock.availableMinutes === "number"
+      ? nextFreeBlock.availableMinutes
+      : 240
+  );
+
+  startCountdown(end, isEvent, availableMinutes);
+}
+
+function clearCountdown() {
+  if (countdownInterval) {
+    clearInterval(countdownInterval);
+    countdownInterval = null;
+  }
+
+  updateTimeRemainingDisplay(null);
+
+  if (countdownAlert) {
+    countdownAlert.style.display = "none";
+  }
+
+  if (countdownText) {
+    countdownText.textContent = "";
+  }
+}
+
+function startCountdown(endTime, isEvent, availableMinutes) {
+  clearCountdown();
+
+  const alertThreshold = isEvent ? 30 : 15;
+  const chimeSound = new Audio(
+    isEvent ? "30_minute_warning.wav" : "15_minute_warning.wav"
+  );
+
+  let alertPlayed = false;
+
+  countdownInterval = setInterval(() => {
+    const now = new Date();
+    const msRemaining = endTime - now;
+
+    if (msRemaining <= 0) {
+      clearCountdown();
+      sessionTimeText.textContent = "Session ended";
+      extensionDiv.innerHTML = "";
+      return;
+    }
+
+    updateTimeRemainingDisplay(msRemaining);
+
+    const minsRemaining = Math.floor(msRemaining / (60 * 1000));
+
+    if (minsRemaining === alertThreshold && !alertPlayed) {
+      alertPlayed = true;
+      if (countdownText) {
+        countdownText.textContent = `${alertThreshold} minutes remaining`;
+      }
+      if (countdownAlert) {
+        countdownAlert.style.display = "inline-block";
+      }
+      chimeSound.play().catch((err) => console.log("Autoplay blocked:", err));
+      showExtensionButtons(availableMinutes, isEvent);
+    }
+  }, 1000);
+}
+
+function updateTimeRemainingDisplay(msRemaining) {
+  if (!timeRemainingEl) return;
+
+  if (msRemaining && msRemaining > 0) {
+    const minsRemaining = Math.floor(msRemaining / (60 * 1000));
+    const secsRemaining = Math.floor((msRemaining % (60 * 1000)) / 1000);
+    const hrs = Math.floor(minsRemaining / 60);
+    const mins = minsRemaining % 60;
+    const secs = secsRemaining;
+
+    let formatted;
+    if (hrs > 0) {
+      formatted = `${hrs}:${String(mins).padStart(2, "0")}:${String(secs).padStart(
+        2,
+        "0"
+      )}`;
+    } else {
+      formatted = `${String(mins).padStart(2, "0")}:${String(secs).padStart(
+        2,
+        "0"
+      )}`;
+    }
+
+    timeRemainingEl.textContent = formatted;
+  } else {
+    timeRemainingEl.textContent = "";
+  }
 }
 
 function formatTime(date) {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function extractClientName(evt, isEvent) {
-  if (!evt.summary) return "";
-  return isEvent ? evt.summary.trim() : evt.summary.split(":")[0].trim();
+function extractClientName(summary, isEvent) {
+  if (!summary) return "";
+  return isEvent ? summary.trim() : summary.split(":")[0].trim();
 }
 
 function displayClientName(name) {
@@ -143,183 +195,72 @@ function displayClientName(name) {
     el = document.createElement("p");
     el.id = "client-name";
     el.style.fontWeight = "bold";
-    el.style.fontSize   = "1.5rem";
+    el.style.fontSize = "1.5rem";
     sessionTimeText.parentElement.insertBefore(el, sessionTimeText);
   }
+
   el.textContent = name;
 }
 
-// ------------------- Countdown & Time-Remaining Display -------------------
-function startCountdown(endTime, isEvent, events) {
-  const alertThreshold = isEvent ? 30 : 15;
-  const chimeSound     = new Audio(isEvent ? "30_minute_warning.wav" : "15_minute_warning.wav");
-
-  // Find the next event that starts after this one ends
-  const nextEvt = events.find(evt => new Date(evt.start.dateTime) > endTime);
-  const availableMinutes = nextEvt
-    ? Math.floor((new Date(nextEvt.start.dateTime) - endTime) / (60 * 1000))
-    : 240; // fallback: assume 4 hours free
-
-  let alertPlayed = false;
-
-  const interval = setInterval(() => {
-    const now           = new Date();
-    const msRemaining   = endTime - now;
-    const minsRemaining = Math.floor(msRemaining / (60 * 1000));
-    const secsRemaining = Math.floor((msRemaining % (60 * 1000)) / 1000);
-
-    // ⏳ Update “Time Remaining” in H:MM:SS or MM:SS format
-    const timeRemainingEl = document.getElementById("time-remaining");
-    if (timeRemainingEl) {
-      if (msRemaining > 0) {
-        const hrs  = Math.floor(minsRemaining / 60);
-        const mins = minsRemaining % 60;
-        const secs = secsRemaining;
-        let formatted;
-
-        if (hrs > 0) {
-          formatted = `${hrs}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
-        } else {
-          formatted = `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
-        }
-        timeRemainingEl.textContent = formatted;
-      } else {
-        timeRemainingEl.textContent = "";
-      }
-    }
-
-    // Only play the chime once at threshold
-    if (minsRemaining === alertThreshold && msRemaining > 0 && !alertPlayed) {
-      alertPlayed = true;
-      countdownText.textContent     = `${alertThreshold} minutes remaining`;
-      countdownAlert.style.display  = "inline-block";
-      chimeSound.play().catch(err => console.log("Autoplay blocked:", err));
-      showExtensionButtons(availableMinutes, isEvent);
-    }
-
-    // When time’s up, clear things
-    if (msRemaining <= 0) {
-      clearInterval(interval);
-      countdownText.textContent     = "Session ended";
-      countdownAlert.style.display  = "none";
-      extensionDiv.innerHTML        = "";
-      if (timeRemainingEl) timeRemainingEl.textContent = "";
-    }
-  }, 1000);
-}
-
-// ------------------- Show “Extend” Buttons & Patch Calendar & Log to Sheet -------------------
 function showExtensionButtons(availableMinutes, isEvent = false) {
-  extensionDiv.innerHTML = ""; // Clear existing buttons
+  extensionDiv.innerHTML = "";
 
-  const options = isEvent
-    ? [
-        { minutes: 30, price: "$53.10" },
-        { minutes: 60, price: "$106.20" }
-      ]
-    : extensionOptions;
+  const options = isEvent ? eventExtensionOptions : extensionOptions;
 
-  options.forEach(option => {
-    if (availableMinutes >= option.minutes) {
-      const button = document.createElement("button");
-      button.textContent = `Extend ${option.minutes} Minutes (${option.price})`;
+  options.forEach((option) => {
+    if (availableMinutes < option.minutes) {
+      return;
+    }
 
-      button.onclick = async () => {
-        const confirmed = confirm(
-          `Extend session for ${option.minutes} minutes (${option.price})?`
-        );
-        if (!confirmed) return;
+    const button = document.createElement("button");
+    button.textContent = `Extend ${option.minutes} Minutes (${option.price})`;
 
-        // 1) Calculate new end time
-        const newEnd = new Date(
-          window.sessionEndTime.getTime() + option.minutes * 60000
-        );
+    button.onclick = async () => {
+      const confirmed = confirm(
+        `Extend session for ${option.minutes} minutes (${option.price})?`
+      );
+      if (!confirmed) return;
 
-        // 2) Build updated title (append [EXTENDED] if needed)
-        const originalTitle   = window.originalEventTitle || "Session";
-        const alreadyExtended = originalTitle.includes("[EXTENDED]");
-        const updatedTitle    = alreadyExtended
-          ? originalTitle
-          : `${originalTitle} [EXTENDED]`;
+      button.disabled = true;
 
-        // 3) Build appended description
-        const timestamp  = new Date().toLocaleTimeString();
-        const appendText = `${timestamp} — Client extended their session by ${option.minutes} minutes.`;
-        const newDescription = window.currentEventDescription
-          ? appendText + "\n" + window.currentEventDescription
-          : appendText;
-
-        // 4) Patch the Calendar event
-        const patchBody = {
-          summary: updatedTitle,
-          end: {
-            dateTime: newEnd.toISOString(),
-            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
-          },
-          description: newDescription
-        };
-
-        try {
-          await gapi.client.calendar.events.patch({
-            calendarId: "2l28nlc148jqqc7uk24u5jr9cs@group.calendar.google.com",
-            eventId:    window.currentEventId,
-            resource:   patchBody
-          });
-
-         // 5) Build data for the Sheets row
-const formattedDate = window.sessionStartTime.toLocaleDateString(undefined, {
-  month:  "long",
-  day:    "numeric",
-  year:   "numeric"
-});
-const originalRange = `${formattedDate} ${formatTime(window.sessionStartTime)} – ${formatTime(window.sessionEndTime)}`;
-const newTimeRange  = `${formatTime(window.sessionStartTime)} – ${formatTime(newEnd)}`;
-
-const durationLabel   = option.minutes === 60
-  ? "1 hour"
-  : `${option.minutes} minutes`;
-const total = option.price;
-
-// 6) Clean off “(White Space Studio)” if present
-const cleanedTitle = originalTitle.replace(
-  /\s*\(White Space Studio\)/i,
-  ""
-).trim();
-
-// 7) Append directly via Sheets API
-const SPREADSHEET_ID = "1AhJHK4wWg_c3aOclzqbJ1XZf9L1mBafik-MtQub77Zo";
-const SHEET_NAME     = "Session_Extensions";
-const range          = `${SHEET_NAME}!A:E`;
-
-const values = [[
-  window.sessionClientName, // A: Name
-  originalRange,            // B: Original Appointment
-  newTimeRange,             // C: New Time
-  durationLabel,            // D: Duration
-  total                     // E: Total
-]];
-
-await gapi.client.sheets.spreadsheets.values.append({
-  spreadsheetId:    SPREADSHEET_ID,
-  range:            range,
-  valueInputOption: "USER_ENTERED",
-  resource:         { values: values }
-});
-          console.log("✅ Successfully updated Calendar and appended row to Sheet.");
-
-          // 8) Update in-memory values & reload UI
-          window.sessionEndTime          = newEnd;
-          window.originalEventTitle      = updatedTitle;
-          window.currentEventDescription = newDescription;
-          location.reload();
-
-        } catch (err) {
-          console.error("❌ Error extending session:", err);
-          alert("❌ Failed to update Calendar or append row to Sheet.");
-        }
+      const payload = {
+        eventId: window.currentEventId,
+        originalTitle: window.originalEventTitle,
+        currentEnd: window.sessionEndTime.toISOString(),
+        extendMinutes: option.minutes,
+        description: window.currentEventDescription,
+        clientName: window.sessionClientName,
+        durationLabel:
+          option.minutes === 60 ? "1 hour" : `${option.minutes} minutes`,
+        extensionAmount: option.price,
       };
 
-      extensionDiv.appendChild(button);
-    }
+      try {
+        const response = await fetch(`${API_BASE_URL}/extend-session`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const result = await response.json();
+        if (!result.success) {
+          throw new Error("Unexpected response from server");
+        }
+
+        console.log("✅ Successfully requested session extension.");
+        await loadActiveSession();
+      } catch (err) {
+        console.error("❌ Error extending session:", err);
+        alert("❌ Failed to update session. Please notify staff.");
+      } finally {
+        button.disabled = false;
+      }
+    };
+
+    extensionDiv.appendChild(button);
   });
 }


### PR DESCRIPTION
## Summary
- load Google service account credentials from environment and expose a new `/active-session` endpoint for the kiosk
- replace front-end Google API calls with fetches to the Express API for reading the active session and extending bookings
- remove the OAuth button/scripts so the kiosk now communicates only with the server

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cb13020d9883299b63fcfd798b7254